### PR TITLE
look for format parameter in body parameters too

### DIFF
--- a/lib/Plack/Middleware/Negotiate.pm
+++ b/lib/Plack/Middleware/Negotiate.pm
@@ -80,13 +80,9 @@ sub negotiate {
 
     if (defined $self->parameter) {
         my $param = $self->parameter;
-        if ($env->{QUERY_STRING} =~ /(^|&)$param=([^&]+)/) {
-            my $format = $2;
+        if (my $format = $req->param($param)) {
             if ($self->known($format)) {
                 log_trace { "format $format chosen based on query parameter" };
-                unless ( $env->{QUERY_STRING} =~ s/&$param=([^&]+)//) {
-                    $env->{QUERY_STRING} =~ s/^$param=([^&]+)&?//;
-                }
                 return $format;
             }
         }


### PR DESCRIPTION
Hi.

I just integrated this module into a project where we had been doing the content negotiation ourselves. It worked perfectly except our codebase expects to be able to request the format through either a POST parameter or through the query string.

So as you can see, I just replaced the manual QUERY_STRING parsing with a call $req->param. I assume you were doing it manually to minimize performance hit if the application doesn't parse the parameters? As a side effect of that, I'm not trying to remove the parameter before it reaches the application.

Anyway, I assume you will probably not like this diff, but wanted to let you know your module is being used and why I'm forking.

Thanks.
