### PR TITLE
add separate method to create Plack::Request instance so clients can easily override

### DIFF
--- a/lib/Plack/Middleware/Negotiate.pm
+++ b/lib/Plack/Middleware/Negotiate.pm
@@ -79,9 +79,13 @@ sub add_headers {
 
 }
 
+
+sub _new_plack_request { Plack::Request->new($_[1]) }
+
+
 sub negotiate {
     my ($self, $env) = @_;
-    my $req = Plack::Request->new($env);
+    my $req = $self->_new_plack_request($env);
 
     if (defined $self->parameter) {
         my $param = $self->parameter;


### PR DESCRIPTION
In a project I was using a subclass of Plack::Request that modifies how parameters are handled. I couldn't figure out why it didn't seem to called.

Turns out it was b/c Negotiate was handling the request first. It instantiated a normal Plack::Request instance to access body parameters. That modified the $env so when my request subclass was finally instantiated, the parameters were already parsed and cached in.

Just adding a level of indirection so it's easy to override the default Plack::Request class.